### PR TITLE
#define st_mtim st_mtimespec so that compiles on macOS

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -197,6 +197,11 @@ update_test(const char *dst_path,
 
 	struct stat src_st;
 	stat(src_path, &src_st);
+	
+#if (defined __APPLE__)
+#pragma push_macro("st_mtim")
+#define st_mtim st_mtimespec
+#endif
 
 	if (src_st.st_mtim.tv_sec > dst_st.st_mtim.tv_sec) {
 		return true;
@@ -205,6 +210,10 @@ update_test(const char *dst_path,
 	if (src_st.st_mtim.tv_nsec > dst_st.st_mtim.tv_nsec) {
 		return true;
 	}
+
+#if (defined __APPLE__)
+#pragma pop_macro("st_mtim")
+#endif
 
 	return false;
 #endif


### PR DESCRIPTION
Define macro st_mtim st_mtimespec on macOS
st_mtim is saved before define in case causing compile errors on other platforms

Compile environment:
```
macOS 10.12 Beta (16A313a)
cmake version 3.4.3
Apple LLVM version 8.0.0 (clang-800.0.38)
Target: x86_64-apple-darwin16.0.0
Thread model: posix
```